### PR TITLE
chore: set up native maven plugin and add fix for native image compilation for sample

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -336,10 +336,77 @@
 					</execution>
 				</executions>
 			</plugin>
+			<plugin>
+				<groupId>org.graalvm.buildtools</groupId>
+				<artifactId>native-maven-plugin</artifactId>
+				<extensions>true</extensions>
+			</plugin>
 		</plugins>
 	</build>
 
 	<profiles>
+		<profile>
+			<id>spring-native</id>
+			<dependencies>
+				<dependency>
+					<groupId>org.junit.platform</groupId>
+					<artifactId>junit-platform-launcher</artifactId>
+					<version>1.9.2</version>
+					<scope>test</scope>
+				</dependency>
+			</dependencies>
+			<build>
+				<plugins>
+					<plugin>
+						<groupId>org.apache.maven.plugins</groupId>
+						<artifactId>maven-surefire-plugin</artifactId>
+						<version>3.0.0</version>
+						<configuration>
+							<!-- https://docs.spring.io/spring-boot/docs/current/maven-plugin/reference/htmlsingle/#integration-tests.no-starter-parent -->
+							<excludes combine.self="override" />
+							<includes>
+								<include>**/PubSubAdminTests</include>
+							</includes>
+							<classesDirectory>${project.build.outputDirectory}</classesDirectory>
+						</configuration>
+					</plugin>
+					<plugin>
+						<groupId>org.graalvm.buildtools</groupId>
+						<artifactId>native-maven-plugin</artifactId>
+						<version>0.9.20</version>
+						<configuration>
+							<classesDirectory>${project.build.outputDirectory}</classesDirectory>
+							<metadataRepository>
+								<enabled>true</enabled>
+							</metadataRepository>
+						</configuration>
+						<executions>
+							<execution>
+								<id>native-test</id>
+								<goals>
+									<goal>test</goal>
+								</goals>
+								<phase>test</phase>
+							</execution>
+						</executions>
+					</plugin>
+					<plugin>
+						<groupId>org.springframework.boot</groupId>
+						<artifactId>spring-boot-maven-plugin</artifactId>
+						<version>3.0.5</version>
+						<executions>
+							<execution>
+								<id>process-test-aot</id>
+								<goals>
+									<goal>process-test-aot</goal>
+								</goals>
+							</execution>
+						</executions>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
+		
 		<profile>
 			<id>default</id>
 			<activation>

--- a/pom.xml
+++ b/pom.xml
@@ -336,76 +336,10 @@
 					</execution>
 				</executions>
 			</plugin>
-			<plugin>
-				<groupId>org.graalvm.buildtools</groupId>
-				<artifactId>native-maven-plugin</artifactId>
-				<extensions>true</extensions>
-			</plugin>
 		</plugins>
 	</build>
 
 	<profiles>
-		<profile>
-			<id>spring-native</id>
-			<dependencies>
-				<dependency>
-					<groupId>org.junit.platform</groupId>
-					<artifactId>junit-platform-launcher</artifactId>
-					<version>1.9.2</version>
-					<scope>test</scope>
-				</dependency>
-			</dependencies>
-			<build>
-				<plugins>
-					<plugin>
-						<groupId>org.apache.maven.plugins</groupId>
-						<artifactId>maven-surefire-plugin</artifactId>
-						<version>3.0.0</version>
-						<configuration>
-							<!-- https://docs.spring.io/spring-boot/docs/current/maven-plugin/reference/htmlsingle/#integration-tests.no-starter-parent -->
-							<excludes combine.self="override" />
-							<includes>
-								<include>**/PubSubAdminTests</include>
-							</includes>
-							<classesDirectory>${project.build.outputDirectory}</classesDirectory>
-						</configuration>
-					</plugin>
-					<plugin>
-						<groupId>org.graalvm.buildtools</groupId>
-						<artifactId>native-maven-plugin</artifactId>
-						<version>0.9.20</version>
-						<configuration>
-							<classesDirectory>${project.build.outputDirectory}</classesDirectory>
-							<metadataRepository>
-								<enabled>true</enabled>
-							</metadataRepository>
-						</configuration>
-						<executions>
-							<execution>
-								<id>native-test</id>
-								<goals>
-									<goal>test</goal>
-								</goals>
-								<phase>test</phase>
-							</execution>
-						</executions>
-					</plugin>
-					<plugin>
-						<groupId>org.springframework.boot</groupId>
-						<artifactId>spring-boot-maven-plugin</artifactId>
-						<version>3.0.5</version>
-						<executions>
-							<execution>
-								<id>process-test-aot</id>
-								<goals>
-									<goal>process-test-aot</goal>
-								</goals>
-							</execution>
-						</executions>
-					</plugin>
-				</plugins>
-			</build>
-		</profile>
 		
 		<profile>
 			<id>default</id>

--- a/pom.xml
+++ b/pom.xml
@@ -587,8 +587,8 @@
 					<plugins>
 						<plugin>
 							<groupId>org.apache.maven.plugins</groupId>
-							<artifactId>${maven-compiler-plugin.version}</artifactId>
-							<version>3.10.1</version>
+							<artifactId>maven-compiler-plugin</artifactId>
+							<version>${maven-compiler-plugin.version}</version>
 							<configuration>
 								<source>${maven.compiler.source}</source>
 								<target>${maven.compiler.target}</target>
@@ -596,11 +596,7 @@
 								<fork>true</fork>
 								<compilerArgs>
 									<arg>-XDcompilePolicy=simple</arg>
-									<arg>
-										-Xplugin:ErrorProne \
-										-Xep:UnicodeInCode:OFF \
-										-Xep:CanIgnoreReturnValue:OFF
-									</arg>
+									<arg>-Xplugin:ErrorProne</arg>
 									<!-- See: https://github.com/GoogleCloudPlatform/spring-cloud-gcp/pull/92 -->
 									<arg>-parameters</arg>
 									<arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED</arg>

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-secretmanager-sample/pom.xml
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-secretmanager-sample/pom.xml
@@ -74,6 +74,23 @@
           <skip>true</skip>
         </configuration>
       </plugin>
+
+      <plugin>
+        <groupId>org.graalvm.buildtools</groupId>
+        <artifactId>native-maven-plugin</artifactId>
+        <version>0.9.20</version>
+        <configuration>
+          <buildArgs>
+            <buildArg>--trace-class-initialization=org.apache.commons.logging.LogFactoryService</buildArg>
+            <buildArg>--initialize-at-build-time=org.apache.commons.logging.LogFactory</buildArg>
+          </buildArgs>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-maven-plugin</artifactId>
+      </plugin>
     </plugins>
   </build>
+
 </project>


### PR DESCRIPTION
(1) The sample transitively brings in  `spring-boot-starter-parent` as the parent through `spring-cloud-gcp-samples`. The Spring Boot starter already provides a `native` profile with some defaults so we need to define the following plugins in our pom.xml to take advantage of it:

```
<plugin>
    <groupId>org.graalvm.buildtools</groupId>
    <artifactId>native-maven-plugin</artifactId>
</plugin>
<plugin>
    <groupId>org.springframework.boot</groupId>
    <artifactId>spring-boot-maven-plugin</artifactId>
</plugin>
```

(2) Adds `--initialize-at-build-time=org.apache.commons.logging.LogFactory` to resolve the build-time failure:
```
Error: Classes that should be initialized at run time got initialized during image building:
 org.apache.commons.logging.LogFactory was unintentionally initialized at build time. To see why org.apache.commons.logging.LogFactory got initialized use --trace-class-initialization=org.apache.commons.logging.LogFactory
org.apache.commons.logging.LogFactoryService was unintentionally initialized at build time. org.springframework.web.servlet.mvc.method.annotation.ReactiveTypeHandler caused initialization of this class with the following trace: 
	at org.apache.commons.logging.LogFactoryService.<clinit>(LogFactoryService.java)
	at jdk.internal.reflect.NativeConstructorAccessorImpl.newInstance0(Unknown Source)
	at jdk.internal.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:77)
	at jdk.internal.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45)
	at java.lang.reflect.Constructor.newInstanceWithCaller(Constructor.java:499)
	at java.lang.reflect.ReflectAccess.newInstance(ReflectAccess.java:128)
	at jdk.internal.reflect.ReflectionFactory.newInstance(ReflectionFactory.java:347)
	at java.lang.Class.newInstance(Class.java:645)
	at org.apache.commons.logging.LogFactory.createFactory(LogFactory.java:1047)
	at org.apache.commons.logging.LogFactory$2.run(LogFactory.java:960)
	at java.security.AccessController.executePrivileged(AccessController.java:776)
	at java.security.AccessController.doPrivileged(AccessController.java:318)
	at org.apache.commons.logging.LogFactory.newFactory(LogFactory.java:957)
	at org.apache.commons.logging.LogFactory.getFactory(LogFactory.java:552)
	at org.apache.commons.logging.LogFactory.getLog(LogFactory.java:655)
	at org.springframework.web.servlet.mvc.method.annotation.ReactiveTypeHandler.<clinit>(ReactiveTypeHandler.java:88)
```