### PR TITLE
fix: fix vision integration tests with native

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ dependency-reduced-pom.xml
 
 .flattened-pom.xml
 *.versionsBackup
+
+# ignore tracing agent outputs
+**/native-image-config

--- a/pom.xml
+++ b/pom.xml
@@ -336,10 +336,87 @@
 					</execution>
 				</executions>
 			</plugin>
+
+			<plugin>
+				<groupId>org.graalvm.buildtools</groupId>
+				<artifactId>native-maven-plugin</artifactId>
+				<version>0.9.20</version>
+				<extensions>true</extensions>
+			</plugin>
 		</plugins>
 	</build>
 
 	<profiles>
+	<profile>
+		<id>spring-native</id>
+
+		<dependencies>
+			<dependency>
+				<groupId>org.junit.platform</groupId>
+				<artifactId>junit-platform-launcher</artifactId>
+				<version>1.9.2</version>
+				<scope>test</scope>
+			</dependency>
+		</dependencies>
+		<build>
+			<plugins>
+				<plugin>
+					<groupId>org.apache.maven.plugins</groupId>
+					<artifactId>maven-surefire-plugin</artifactId>
+					<version>3.0.0</version>
+					<configuration>
+						<!-- https://docs.spring.io/spring-boot/docs/current/maven-plugin/reference/htmlsingle/#integration-tests.no-starter-parent -->
+						<excludes combine.self="override" />
+						<includes>
+							<!--including all integration tests for testing purposes.-->
+							<include>**/*IntegrationTests.java</include>
+						</includes>
+						<classesDirectory>${project.build.outputDirectory}</classesDirectory>
+						<systemProperties>
+						</systemProperties>
+					</configuration>
+				</plugin>
+				<plugin>
+					<groupId>org.graalvm.buildtools</groupId>
+					<artifactId>native-maven-plugin</artifactId>
+					<version>0.9.20</version>
+					<configuration>
+						<buildArgs>
+							<buildArg>--trace-class-initialization=org.apache.commons.logging.LogFactoryService</buildArg>
+							<buildArg>--initialize-at-build-time=org.apache.commons.logging.LogFactory</buildArg>
+						</buildArgs>
+						<classesDirectory>${project.build.outputDirectory}</classesDirectory>
+						<metadataRepository>
+							<enabled>true</enabled>
+						</metadataRepository>
+					</configuration>
+					<executions>
+						<execution>
+							<id>native-test</id>
+							<goals>
+								<goal>test</goal>
+							</goals>
+							<phase>test</phase>
+						</execution>
+					</executions>
+				</plugin>
+				<plugin>
+					<groupId>org.springframework.boot</groupId>
+					<artifactId>spring-boot-maven-plugin</artifactId>
+					<version>3.0.5</version>
+					<executions>
+						<execution>
+							<id>process-test-aot</id>
+							<goals>
+								<goal>process-test-aot</goal>
+							</goals>
+						</execution>
+					</executions>
+				</plugin>
+			</plugins>
+		</build>
+	</profile>
+
 		<profile>
 			<id>default</id>
 			<activation>

--- a/pom.xml
+++ b/pom.xml
@@ -373,6 +373,10 @@
 						</includes>
 						<classesDirectory>${project.build.outputDirectory}</classesDirectory>
 						<systemProperties>
+							<property>
+								<name>it.vision</name>
+								<value>true</value>
+							</property>
 						</systemProperties>
 					</configuration>
 				</plugin>

--- a/spring-cloud-gcp-samples/pom.xml
+++ b/spring-cloud-gcp-samples/pom.xml
@@ -79,6 +79,33 @@
 
 	<profiles>
 		<profile>
+			<id>native-sample</id>
+			<build>
+				<plugins>
+					<plugin>
+						<groupId>org.graalvm.buildtools</groupId>
+						<artifactId>native-maven-plugin</artifactId>
+						<version>0.9.20</version>
+						<configuration>
+							<buildArgs>
+								<buildArg>--trace-class-initialization=org.apache.commons.logging.LogFactoryService</buildArg>
+								<buildArg>--initialize-at-build-time=org.apache.commons.logging.LogFactory</buildArg>
+							</buildArgs>
+						</configuration>
+						<executions>
+							<execution>
+								<id>build-native</id>
+								<goals>
+									<goal>build</goal>
+								</goals>
+								<phase>package</phase>
+							</execution>
+						</executions>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
+		<profile>
 			<id>spring-cloud-gcp-ci-it</id>
 			<build>
 				<plugins>

--- a/spring-cloud-gcp-vision/src/test/java/com/google/cloud/spring/vision/it/CloudVisionTemplateIntegrationTests.java
+++ b/spring-cloud-gcp-vision/src/test/java/com/google/cloud/spring/vision/it/CloudVisionTemplateIntegrationTests.java
@@ -3,11 +3,13 @@ package com.google.cloud.spring.vision.it;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.google.cloud.spring.vision.CloudVisionTemplate;
+import com.google.cloud.spring.vision.nativeimage.TestRuntimeHints;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.ImportRuntimeHints;
 import org.springframework.core.io.ClassPathResource;
 import org.springframework.core.io.Resource;
 import org.springframework.test.context.ContextConfiguration;
@@ -16,6 +18,7 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
 @EnabledIfSystemProperty(named = "it.vision", matches = "true")
 @ExtendWith(SpringExtension.class)
 @ContextConfiguration(classes = {VisionTestConfiguration.class})
+@ImportRuntimeHints(TestRuntimeHints.class)
 class CloudVisionTemplateIntegrationTests {
 
   @Autowired private CloudVisionTemplate cloudVisionTemplate;

--- a/spring-cloud-gcp-vision/src/test/java/com/google/cloud/spring/vision/nativeimage/TestRuntimeHints.java
+++ b/spring-cloud-gcp-vision/src/test/java/com/google/cloud/spring/vision/nativeimage/TestRuntimeHints.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2022-2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.spring.vision.nativeimage;
+
+import org.springframework.aot.hint.RuntimeHints;
+import org.springframework.aot.hint.RuntimeHintsRegistrar;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.core.io.Resource;
+
+public class TestRuntimeHints implements RuntimeHintsRegistrar {
+
+  @Override
+  public void registerHints(RuntimeHints hints, ClassLoader classLoader) {
+    Resource dummyPdf = new ClassPathResource("documents/single-page-dummy.pdf");
+    Resource multiPagePdf = new ClassPathResource("documents/multi-page-dummy.pdf");
+    hints.resources().registerResource(dummyPdf);
+    hints.resources().registerResource(multiPagePdf);
+  }
+}


### PR DESCRIPTION
This pr:
 - Adds `spring-native` profile to project pom run native image tests. Copied from #1, updated configurations to include Vision integration tests (enabled via system property `it.vision`). This setup also excludes unit test runs.
```
<systemProperties>
	<property>
		<name>it.vision</name>
		<value>true</value>
	</property>
</systemProperties>
```
 - Adds  `native-sample` profile to help package sample with GraalVM to run.
 - Adds runtime hints to acknowledge test resources to fix Vision integration native image tests.

To verify native image test run successfully for Vision integration tests, 
```
sdk use java 22.3.r17-grl   
cd spring-cloud-gcp-vision
mvn -Pspring-native clean test     
```
My test results:
```
JUnit Platform on Native Image - report
----------------------------------------


Test run finished after 4 ms
[         4 containers found      ]
[         2 containers skipped    ]
[         2 containers started    ]
[         0 containers aborted    ]
[         2 containers successful ]
[         0 containers failed     ]
[         5 tests found           ]
[         5 tests skipped         ]
[         0 tests started         ]
[         0 tests aborted         ]
[         0 tests successful      ]
[         0 tests failed          ]
```