### PR TITLE
fix: runtime hints for trace sample to work with native

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ dependency-reduced-pom.xml
 
 .flattened-pom.xml
 *.versionsBackup
+
+# ignore tracing agent outputs
+**/native-image-config

--- a/pom.xml
+++ b/pom.xml
@@ -336,10 +336,87 @@
 					</execution>
 				</executions>
 			</plugin>
+
+			<plugin>
+				<groupId>org.graalvm.buildtools</groupId>
+				<artifactId>native-maven-plugin</artifactId>
+				<version>0.9.20</version>
+				<extensions>true</extensions>
+			</plugin>
 		</plugins>
 	</build>
 
 	<profiles>
+	<profile>
+		<id>spring-native</id>
+
+		<dependencies>
+			<dependency>
+				<groupId>org.junit.platform</groupId>
+				<artifactId>junit-platform-launcher</artifactId>
+				<version>1.9.2</version>
+				<scope>test</scope>
+			</dependency>
+		</dependencies>
+		<build>
+			<plugins>
+				<plugin>
+					<groupId>org.apache.maven.plugins</groupId>
+					<artifactId>maven-surefire-plugin</artifactId>
+					<version>3.0.0</version>
+					<configuration>
+						<!-- https://docs.spring.io/spring-boot/docs/current/maven-plugin/reference/htmlsingle/#integration-tests.no-starter-parent -->
+						<excludes combine.self="override" />
+						<includes>
+							<!--including all integration tests for testing purposes.-->
+							<include>**/*IntegrationTests.java</include>
+						</includes>
+						<classesDirectory>${project.build.outputDirectory}</classesDirectory>
+						<systemProperties>
+						</systemProperties>
+					</configuration>
+				</plugin>
+				<plugin>
+					<groupId>org.graalvm.buildtools</groupId>
+					<artifactId>native-maven-plugin</artifactId>
+					<version>0.9.20</version>
+					<configuration>
+						<buildArgs>
+							<buildArg>--trace-class-initialization=org.apache.commons.logging.LogFactoryService</buildArg>
+							<buildArg>--initialize-at-build-time=org.apache.commons.logging.LogFactory</buildArg>
+						</buildArgs>
+						<classesDirectory>${project.build.outputDirectory}</classesDirectory>
+						<metadataRepository>
+							<enabled>true</enabled>
+						</metadataRepository>
+					</configuration>
+					<executions>
+						<execution>
+							<id>native-test</id>
+							<goals>
+								<goal>test</goal>
+							</goals>
+							<phase>test</phase>
+						</execution>
+					</executions>
+				</plugin>
+				<plugin>
+					<groupId>org.springframework.boot</groupId>
+					<artifactId>spring-boot-maven-plugin</artifactId>
+					<version>3.0.5</version>
+					<executions>
+						<execution>
+							<id>process-test-aot</id>
+							<goals>
+								<goal>process-test-aot</goal>
+							</goals>
+						</execution>
+					</executions>
+				</plugin>
+			</plugins>
+		</build>
+	</profile>
+
 		<profile>
 			<id>default</id>
 			<activation>

--- a/spring-cloud-gcp-autoconfigure/src/main/java/com/google/cloud/spring/autoconfigure/trace/StackdriverTraceAutoConfiguration.java
+++ b/spring-cloud-gcp-autoconfigure/src/main/java/com/google/cloud/spring/autoconfigure/trace/StackdriverTraceAutoConfiguration.java
@@ -48,6 +48,7 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.ImportRuntimeHints;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
 import zipkin2.CheckResult;
 import zipkin2.Span;
@@ -64,6 +65,7 @@ import zipkin2.reporter.stackdriver.StackdriverSender.Builder;
 
 /** Config for Stackdriver Trace. */
 @AutoConfiguration
+@ImportRuntimeHints(TraceRuntimeHints.class)
 @EnableConfigurationProperties({GcpTraceProperties.class})
 @ConditionalOnProperty(
     value = {"spring.cloud.gcp.trace.enabled"},

--- a/spring-cloud-gcp-autoconfigure/src/main/java/com/google/cloud/spring/autoconfigure/trace/TraceRuntimeHints.java
+++ b/spring-cloud-gcp-autoconfigure/src/main/java/com/google/cloud/spring/autoconfigure/trace/TraceRuntimeHints.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package com.google.cloud.spring.autoconfigure.trace;
+
+import io.micrometer.observation.aop.ObservedAspect;
+import java.lang.reflect.Method;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.springframework.aot.hint.ExecutableMode;
+import org.springframework.aot.hint.RuntimeHints;
+import org.springframework.aot.hint.RuntimeHintsRegistrar;
+import org.springframework.util.ReflectionUtils;
+
+public class TraceRuntimeHints implements RuntimeHintsRegistrar {
+
+  @Override
+  public void registerHints(RuntimeHints hints, ClassLoader classLoader) {
+    Method method = ReflectionUtils.findMethod(ObservedAspect.class, "observeMethod", ProceedingJoinPoint.class);
+    hints.reflection().registerMethod(method, ExecutableMode.INVOKE);
+  }
+}

--- a/spring-cloud-gcp-samples/pom.xml
+++ b/spring-cloud-gcp-samples/pom.xml
@@ -79,6 +79,33 @@
 
 	<profiles>
 		<profile>
+			<id>native-sample</id>
+			<build>
+				<plugins>
+					<plugin>
+						<groupId>org.graalvm.buildtools</groupId>
+						<artifactId>native-maven-plugin</artifactId>
+						<version>0.9.20</version>
+						<configuration>
+							<buildArgs>
+								<buildArg>--trace-class-initialization=org.apache.commons.logging.LogFactoryService</buildArg>
+								<buildArg>--initialize-at-build-time=org.apache.commons.logging.LogFactory</buildArg>
+							</buildArgs>
+						</configuration>
+						<executions>
+							<execution>
+								<id>build-native</id>
+								<goals>
+									<goal>build</goal>
+								</goals>
+								<phase>package</phase>
+							</execution>
+						</executions>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
+		<profile>
 			<id>spring-cloud-gcp-ci-it</id>
 			<build>
 				<plugins>


### PR DESCRIPTION
This pr: 
- Adds runtime hints to trace autoconfiguration. This change unblocks trace sample, and `spring-cloud-gcp-trace-sample` runs as expected.
- Also adds `native-sample` profile to help package sample with GraalVM to run and `spring-native` profile to project pom run native image tests (see details in #5).
- TODOs: 
    - trace autoconfiguration test are not validated. (mockito)
    - trace sample test not validated.