### PR TITLE
fix(storage): add runtime hints, setups for tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ dependency-reduced-pom.xml
 
 .flattened-pom.xml
 *.versionsBackup
+
+# ignore tracing agent outputs
+**/native-image-config

--- a/pom.xml
+++ b/pom.xml
@@ -336,10 +336,87 @@
 					</execution>
 				</executions>
 			</plugin>
+
+			<plugin>
+				<groupId>org.graalvm.buildtools</groupId>
+				<artifactId>native-maven-plugin</artifactId>
+				<version>0.9.20</version>
+				<extensions>true</extensions>
+			</plugin>
 		</plugins>
 	</build>
 
 	<profiles>
+	<profile>
+		<id>spring-native</id>
+
+		<dependencies>
+			<dependency>
+				<groupId>org.junit.platform</groupId>
+				<artifactId>junit-platform-launcher</artifactId>
+				<version>1.9.2</version>
+				<scope>test</scope>
+			</dependency>
+		</dependencies>
+		<build>
+			<plugins>
+				<plugin>
+					<groupId>org.apache.maven.plugins</groupId>
+					<artifactId>maven-surefire-plugin</artifactId>
+					<version>3.0.0</version>
+					<configuration>
+						<!-- https://docs.spring.io/spring-boot/docs/current/maven-plugin/reference/htmlsingle/#integration-tests.no-starter-parent -->
+						<excludes combine.self="override" />
+						<includes>
+							<!--including all integration tests for testing purposes.-->
+							<include>**/*IntegrationTests.java</include>
+						</includes>
+						<classesDirectory>${project.build.outputDirectory}</classesDirectory>
+						<systemProperties>
+						</systemProperties>
+					</configuration>
+				</plugin>
+				<plugin>
+					<groupId>org.graalvm.buildtools</groupId>
+					<artifactId>native-maven-plugin</artifactId>
+					<version>0.9.20</version>
+					<configuration>
+						<buildArgs>
+							<buildArg>--trace-class-initialization=org.apache.commons.logging.LogFactoryService</buildArg>
+							<buildArg>--initialize-at-build-time=org.apache.commons.logging.LogFactory</buildArg>
+						</buildArgs>
+						<classesDirectory>${project.build.outputDirectory}</classesDirectory>
+						<metadataRepository>
+							<enabled>true</enabled>
+						</metadataRepository>
+					</configuration>
+					<executions>
+						<execution>
+							<id>native-test</id>
+							<goals>
+								<goal>test</goal>
+							</goals>
+							<phase>test</phase>
+						</execution>
+					</executions>
+				</plugin>
+				<plugin>
+					<groupId>org.springframework.boot</groupId>
+					<artifactId>spring-boot-maven-plugin</artifactId>
+					<version>3.0.5</version>
+					<executions>
+						<execution>
+							<id>process-test-aot</id>
+							<goals>
+								<goal>process-test-aot</goal>
+							</goals>
+						</execution>
+					</executions>
+				</plugin>
+			</plugins>
+		</build>
+	</profile>
+
 		<profile>
 			<id>default</id>
 			<activation>

--- a/pom.xml
+++ b/pom.xml
@@ -372,8 +372,9 @@
 							<include>**/*IntegrationTests.java</include>
 						</includes>
 						<classesDirectory>${project.build.outputDirectory}</classesDirectory>
-						<systemProperties>
-						</systemProperties>
+						<systemPropertyVariables>
+							<it.storage>true</it.storage>
+						</systemPropertyVariables>
 					</configuration>
 				</plugin>
 				<plugin>

--- a/spring-cloud-gcp-samples/pom.xml
+++ b/spring-cloud-gcp-samples/pom.xml
@@ -80,25 +80,75 @@
 	<profiles>
 		<profile>
 			<id>native-sample</id>
+			<dependencies>
+				<dependency>
+					<groupId>org.junit.platform</groupId>
+					<artifactId>junit-platform-launcher</artifactId>
+					<version>1.9.2</version>
+					<scope>test</scope>
+				</dependency>
+			</dependencies>
 			<build>
 				<plugins>
+					<plugin>
+						<groupId>org.apache.maven.plugins</groupId>
+						<artifactId>maven-surefire-plugin</artifactId>
+						<version>3.0.0</version>
+						<configuration>
+							<!-- https://docs.spring.io/spring-boot/docs/current/maven-plugin/reference/htmlsingle/#integration-tests.no-starter-parent -->
+							<excludes combine.self="override" />
+							<includes>
+								<!--including all integration tests for testing purposes.-->
+								<include>**/*IntegrationTests.java</include>
+							</includes>
+							<classesDirectory>${project.build.outputDirectory}</classesDirectory>
+							<systemPropertyVariables>
+								<it.storage>true</it.storage>
+							</systemPropertyVariables>
+						</configuration>
+					</plugin>
 					<plugin>
 						<groupId>org.graalvm.buildtools</groupId>
 						<artifactId>native-maven-plugin</artifactId>
 						<version>0.9.20</version>
+						<extensions>true</extensions>
 						<configuration>
 							<buildArgs>
 								<buildArg>--trace-class-initialization=org.apache.commons.logging.LogFactoryService</buildArg>
 								<buildArg>--initialize-at-build-time=org.apache.commons.logging.LogFactory</buildArg>
 							</buildArgs>
+							<classesDirectory>${project.build.outputDirectory}</classesDirectory>
+							<metadataRepository>
+								<enabled>true</enabled>
+							</metadataRepository>
 						</configuration>
 						<executions>
+							<execution>
+								<id>native-test</id>
+								<goals>
+									<goal>test</goal>
+								</goals>
+								<phase>test</phase>
+							</execution>
 							<execution>
 								<id>build-native</id>
 								<goals>
 									<goal>build</goal>
 								</goals>
 								<phase>package</phase>
+							</execution>
+						</executions>
+					</plugin>
+					<plugin>
+						<groupId>org.springframework.boot</groupId>
+						<artifactId>spring-boot-maven-plugin</artifactId>
+						<version>3.0.5</version>
+						<executions>
+							<execution>
+								<id>process-test-aot</id>
+								<goals>
+									<goal>process-test-aot</goal>
+								</goals>
 							</execution>
 						</executions>
 					</plugin>
@@ -143,6 +193,12 @@
 	<build>
 		<pluginManagement>
 			<plugins>
+				<plugin>
+					<groupId>org.graalvm.buildtools</groupId>
+					<artifactId>native-maven-plugin</artifactId>
+					<version>0.9.20</version>
+					<extensions>true</extensions>
+				</plugin>
 				<plugin>
 					<groupId>com.google.cloud.tools</groupId>
 					<artifactId>appengine-maven-plugin</artifactId>

--- a/spring-cloud-gcp-samples/pom.xml
+++ b/spring-cloud-gcp-samples/pom.xml
@@ -79,6 +79,33 @@
 
 	<profiles>
 		<profile>
+			<id>native-sample</id>
+			<build>
+				<plugins>
+					<plugin>
+						<groupId>org.graalvm.buildtools</groupId>
+						<artifactId>native-maven-plugin</artifactId>
+						<version>0.9.20</version>
+						<configuration>
+							<buildArgs>
+								<buildArg>--trace-class-initialization=org.apache.commons.logging.LogFactoryService</buildArg>
+								<buildArg>--initialize-at-build-time=org.apache.commons.logging.LogFactory</buildArg>
+							</buildArgs>
+						</configuration>
+						<executions>
+							<execution>
+								<id>build-native</id>
+								<goals>
+									<goal>build</goal>
+								</goals>
+								<phase>package</phase>
+							</execution>
+						</executions>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
+		<profile>
 			<id>spring-cloud-gcp-ci-it</id>
 			<build>
 				<plugins>

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-integration-storage-sample/src/main/java/com/example/GcsSpringIntegrationApplication.java
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-integration-storage-sample/src/main/java/com/example/GcsSpringIntegrationApplication.java
@@ -32,6 +32,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.ImportRuntimeHints;
 import org.springframework.integration.annotation.InboundChannelAdapter;
 import org.springframework.integration.annotation.Poller;
 import org.springframework.integration.annotation.ServiceActivator;
@@ -42,6 +43,7 @@ import org.springframework.messaging.MessageHandler;
 
 /** Storage Spring Integration sample app. */
 @SpringBootApplication
+@ImportRuntimeHints(MyRuntimeHints.class)
 public class GcsSpringIntegrationApplication {
 
   @Value("${gcs-read-bucket}")

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-integration-storage-sample/src/main/java/com/example/MyRuntimeHints.java
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-integration-storage-sample/src/main/java/com/example/MyRuntimeHints.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example;
+
+import org.springframework.aot.hint.MemberCategory;
+import org.springframework.aot.hint.RuntimeHints;
+import org.springframework.aot.hint.RuntimeHintsRegistrar;
+import org.springframework.aot.hint.TypeReference;
+
+public class MyRuntimeHints implements RuntimeHintsRegistrar {
+
+  @Override
+  public void registerHints(RuntimeHints hints, ClassLoader classLoader) {
+    hints.reflection().registerType(TypeReference.of("com.google.cloud.storage.Blob[]"),
+        MemberCategory.DECLARED_CLASSES);
+  }
+}

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-integration-storage-sample/src/test/java/com/example/GcsSpringIntegrationTests.java
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-integration-storage-sample/src/test/java/com/example/GcsSpringIntegrationTests.java
@@ -41,7 +41,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.context.annotation.PropertySource;
+import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 /**
@@ -53,7 +53,7 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
  */
 @EnabledIfSystemProperty(named = "it.storage", matches = "true")
 @ExtendWith(SpringExtension.class)
-@PropertySource("classpath:application.properties")
+@TestPropertySource(locations = "classpath:application-test.properties")
 @SpringBootTest(classes = {GcsSpringIntegrationApplication.class})
 class GcsSpringIntegrationTests {
 

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-integration-storage-sample/src/test/resources/application-test.properties
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-integration-storage-sample/src/test/resources/application-test.properties
@@ -1,0 +1,3 @@
+gcs-read-bucket=gcp-storage-bucket-sample-input
+gcs-write-bucket=gcp-storage-bucket-sample-output
+gcs-local-directory=/tmp/gcp_integration_tests/integration_storage_sample

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-storage-resource-sample/src/test/java/com/example/GcsSampleApplicationIntegrationTests.java
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-storage-resource-sample/src/test/java/com/example/GcsSampleApplicationIntegrationTests.java
@@ -48,7 +48,8 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
 @ExtendWith(SpringExtension.class)
 @SpringBootTest(
     webEnvironment = WebEnvironment.RANDOM_PORT,
-    classes = {GcsApplication.class})
+    classes = {GcsApplication.class},
+    args = "gcs-resource-test-bucket=gcp-storage-resource-bucket-sample")
 class GcsSampleApplicationIntegrationTests {
 
   @Autowired private Storage storage;


### PR DESCRIPTION
This pr: 
- Adds runtime hints to `spring-cloud-gcp-integration-storage-sample`. This change unblocks sample run. Needs to be further evaluated if it's needed in the storage module instead.
- Also adds `native-sample` profile to help package sample with GraalVM to run and `spring-native` profile to project pom run native image tests (see details in #5). Additionally, added setups to run sample tests.

Test run and verified:

- [ ] Datastore module integration test.
- [ ] `spring-cloud-gcp-integration-storage-sample` it test.
- [ ]  `spring-cloud-gcp-storage-resource-sample` it test.