### PR TITLE
fix(pubsub): fixes for pubsub sample tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ dependency-reduced-pom.xml
 
 .flattened-pom.xml
 *.versionsBackup
+
+# ignore tracing agent outputs
+**/native-image-config

--- a/docs/src/main/asciidoc/datastore.adoc
+++ b/docs/src/main/asciidoc/datastore.adoc
@@ -854,6 +854,13 @@ This feature requires a bean of `DatastoreTransactionManager`, which is provided
 If a method annotated with `@Transactional` calls another method also annotated, then both methods will work within the same transaction.
 `performTransaction` cannot be used in `@Transactional` annotated methods because Cloud Datastore does not support transactions within transactions.
 
+Other Google Cloud database-related integrations like Spanner and Firestore can introduce `PlatformTransactionManager` beans, and can interfere with Datastore Transaction Manager. To disambiguate, explicitly specify the name of the transaction manager bean for such `@Transactional` methods. Example:
+
+[source,java]
+----
+@Transactional(transactionManager = "datastoreTransactionManager")
+----
+
 ==== Read-Write Support for Maps
 
 You can work with Maps of type `Map<String, ?>` instead of with entity objects by directly reading and writing them to and from Cloud Datastore.

--- a/docs/src/main/asciidoc/spanner.adoc
+++ b/docs/src/main/asciidoc/spanner.adoc
@@ -956,6 +956,14 @@ This feature requires a bean of `SpannerTransactionManager`, which is provided w
 If a method annotated with `@Transactional` calls another method also annotated, then both methods will work within the same transaction.
 `performReadOnlyTransaction` and `performReadWriteTransaction` cannot be used in `@Transactional` annotated methods because Cloud Spanner does not support transactions within transactions.
 
+Other Google Cloud database-related integrations like Spanner and Firestore can introduce `PlatformTransactionManager` beans, and can interfere with Datastore Transaction Manager. To disambiguate, explicitly specify the name of the transaction manager bean for such `@Transactional` methods. Example:
+
+[source,java]
+----
+@Transactional(transactionManager = "spannerTransactionManager")
+----
+
+
 ==== DML Statements
 
 `SpannerTemplate` supports https://cloud.google.com/spanner/docs/dml-tasks:[DML] `Statements`.

--- a/docs/src/main/md/datastore.md
+++ b/docs/src/main/md/datastore.md
@@ -944,6 +944,15 @@ same transaction. `performTransaction` cannot be used in
 `@Transactional` annotated methods because Cloud Datastore does not
 support transactions within transactions.
 
+Other Google Cloud database-related integrations like Spanner and Firestore can
+introduce `PlatformTransactionManager` beans, and can interfere with Datastore
+Transaction Manager. To disambiguate, explicitly specify the name of the
+transaction manager bean for such `@Transactional` methods. Example:
+
+```java
+@Transactional(transactionManager = "datastoreTransactionManager")
+```
+
 #### Read-Write Support for Maps
 
 You can work with Maps of type `Map<String, ?>` instead of with entity

--- a/docs/src/main/md/spanner.md
+++ b/docs/src/main/md/spanner.md
@@ -1123,6 +1123,15 @@ same transaction. `performReadOnlyTransaction` and
 annotated methods because Cloud Spanner does not support transactions
 within transactions.
 
+Other Google Cloud database-related integrations like Spanner and Firestore can
+introduce `PlatformTransactionManager` beans, and can interfere with Datastore
+Transaction Manager. To disambiguate, explicitly specify the name of the
+transaction manager bean for such `@Transactional` methods. Example:
+
+```java
+@Transactional(transactionManager = "spannerTransactionManager")
+```
+
 #### DML Statements
 
 `SpannerTemplate` supports

--- a/pom.xml
+++ b/pom.xml
@@ -336,10 +336,87 @@
 					</execution>
 				</executions>
 			</plugin>
+
+			<plugin>
+				<groupId>org.graalvm.buildtools</groupId>
+				<artifactId>native-maven-plugin</artifactId>
+				<version>0.9.20</version>
+				<extensions>true</extensions>
+			</plugin>
 		</plugins>
 	</build>
 
 	<profiles>
+	<profile>
+		<id>spring-native</id>
+
+		<dependencies>
+			<dependency>
+				<groupId>org.junit.platform</groupId>
+				<artifactId>junit-platform-launcher</artifactId>
+				<version>1.9.2</version>
+				<scope>test</scope>
+			</dependency>
+		</dependencies>
+		<build>
+			<plugins>
+				<plugin>
+					<groupId>org.apache.maven.plugins</groupId>
+					<artifactId>maven-surefire-plugin</artifactId>
+					<version>3.0.0</version>
+					<configuration>
+						<!-- https://docs.spring.io/spring-boot/docs/current/maven-plugin/reference/htmlsingle/#integration-tests.no-starter-parent -->
+						<excludes combine.self="override" />
+						<includes>
+							<!--including all integration tests for testing purposes.-->
+							<include>**/*IntegrationTests.java</include>
+						</includes>
+						<classesDirectory>${project.build.outputDirectory}</classesDirectory>
+						<systemProperties>
+						</systemProperties>
+					</configuration>
+				</plugin>
+				<plugin>
+					<groupId>org.graalvm.buildtools</groupId>
+					<artifactId>native-maven-plugin</artifactId>
+					<version>0.9.20</version>
+					<configuration>
+						<buildArgs>
+							<buildArg>--trace-class-initialization=org.apache.commons.logging.LogFactoryService</buildArg>
+							<buildArg>--initialize-at-build-time=org.apache.commons.logging.LogFactory</buildArg>
+						</buildArgs>
+						<classesDirectory>${project.build.outputDirectory}</classesDirectory>
+						<metadataRepository>
+							<enabled>true</enabled>
+						</metadataRepository>
+					</configuration>
+					<executions>
+						<execution>
+							<id>native-test</id>
+							<goals>
+								<goal>test</goal>
+							</goals>
+							<phase>test</phase>
+						</execution>
+					</executions>
+				</plugin>
+				<plugin>
+					<groupId>org.springframework.boot</groupId>
+					<artifactId>spring-boot-maven-plugin</artifactId>
+					<version>3.0.5</version>
+					<executions>
+						<execution>
+							<id>process-test-aot</id>
+							<goals>
+								<goal>process-test-aot</goal>
+							</goals>
+						</execution>
+					</executions>
+				</plugin>
+			</plugins>
+		</build>
+	</profile>
+
 		<profile>
 			<id>default</id>
 			<activation>

--- a/spring-cloud-gcp-autoconfigure/src/main/java/com/google/cloud/spring/autoconfigure/datastore/DatastoreTransactionManagerAutoConfiguration.java
+++ b/spring-cloud-gcp-autoconfigure/src/main/java/com/google/cloud/spring/autoconfigure/datastore/DatastoreTransactionManagerAutoConfiguration.java
@@ -26,7 +26,6 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.autoconfigure.transaction.TransactionAutoConfiguration;
 import org.springframework.boot.autoconfigure.transaction.TransactionManagerCustomizers;
 import org.springframework.context.annotation.Bean;
-import org.springframework.transaction.PlatformTransactionManager;
 
 /**
  * Auto-configuration for {@link DatastoreTransactionManager}.
@@ -59,7 +58,7 @@ public class DatastoreTransactionManagerAutoConfiguration {
     }
 
     @Bean
-    @ConditionalOnMissingBean(PlatformTransactionManager.class)
+    @ConditionalOnMissingBean
     public DatastoreTransactionManager datastoreTransactionManager() {
       DatastoreTransactionManager transactionManager =
           new DatastoreTransactionManager(this.datastore);

--- a/spring-cloud-gcp-autoconfigure/src/main/java/com/google/cloud/spring/autoconfigure/spanner/SpannerTransactionManagerAutoConfiguration.java
+++ b/spring-cloud-gcp-autoconfigure/src/main/java/com/google/cloud/spring/autoconfigure/spanner/SpannerTransactionManagerAutoConfiguration.java
@@ -28,7 +28,6 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.autoconfigure.transaction.TransactionAutoConfiguration;
 import org.springframework.boot.autoconfigure.transaction.TransactionManagerCustomizers;
 import org.springframework.context.annotation.Bean;
-import org.springframework.transaction.PlatformTransactionManager;
 
 /**
  * Auto-configuration for {@link SpannerTransactionManager}.
@@ -61,7 +60,7 @@ public class SpannerTransactionManagerAutoConfiguration {
     }
 
     @Bean
-    @ConditionalOnMissingBean(PlatformTransactionManager.class)
+    @ConditionalOnMissingBean
     public SpannerTransactionManager spannerTransactionManager() {
       SpannerTransactionManager transactionManager =
           new SpannerTransactionManager(this.databaseClientProvider);

--- a/spring-cloud-gcp-samples/pom.xml
+++ b/spring-cloud-gcp-samples/pom.xml
@@ -80,25 +80,75 @@
 	<profiles>
 		<profile>
 			<id>native-sample</id>
+			<dependencies>
+				<dependency>
+					<groupId>org.junit.platform</groupId>
+					<artifactId>junit-platform-launcher</artifactId>
+					<version>1.9.2</version>
+					<scope>test</scope>
+				</dependency>
+			</dependencies>
 			<build>
 				<plugins>
+					<plugin>
+						<groupId>org.apache.maven.plugins</groupId>
+						<artifactId>maven-surefire-plugin</artifactId>
+						<version>3.0.0</version>
+						<configuration>
+							<!-- https://docs.spring.io/spring-boot/docs/current/maven-plugin/reference/htmlsingle/#integration-tests.no-starter-parent -->
+							<excludes combine.self="override" />
+							<includes>
+								<!--including all integration tests for testing purposes.-->
+								<include>**/*IntegrationTests.java</include>
+							</includes>
+							<classesDirectory>${project.build.outputDirectory}</classesDirectory>
+							<systemPropertyVariables>
+								<it.storage>true</it.storage>
+							</systemPropertyVariables>
+						</configuration>
+					</plugin>
 					<plugin>
 						<groupId>org.graalvm.buildtools</groupId>
 						<artifactId>native-maven-plugin</artifactId>
 						<version>0.9.20</version>
+						<extensions>true</extensions>
 						<configuration>
 							<buildArgs>
 								<buildArg>--trace-class-initialization=org.apache.commons.logging.LogFactoryService</buildArg>
 								<buildArg>--initialize-at-build-time=org.apache.commons.logging.LogFactory</buildArg>
 							</buildArgs>
+							<classesDirectory>${project.build.outputDirectory}</classesDirectory>
+							<metadataRepository>
+								<enabled>true</enabled>
+							</metadataRepository>
 						</configuration>
 						<executions>
+							<execution>
+								<id>native-test</id>
+								<goals>
+									<goal>test</goal>
+								</goals>
+								<phase>test</phase>
+							</execution>
 							<execution>
 								<id>build-native</id>
 								<goals>
 									<goal>build</goal>
 								</goals>
 								<phase>package</phase>
+							</execution>
+						</executions>
+					</plugin>
+					<plugin>
+						<groupId>org.springframework.boot</groupId>
+						<artifactId>spring-boot-maven-plugin</artifactId>
+						<version>3.0.5</version>
+						<executions>
+							<execution>
+								<id>process-test-aot</id>
+								<goals>
+									<goal>process-test-aot</goal>
+								</goals>
 							</execution>
 						</executions>
 					</plugin>
@@ -143,6 +193,12 @@
 	<build>
 		<pluginManagement>
 			<plugins>
+				<plugin>
+					<groupId>org.graalvm.buildtools</groupId>
+					<artifactId>native-maven-plugin</artifactId>
+					<version>0.9.20</version>
+					<extensions>true</extensions>
+				</plugin>
 				<plugin>
 					<groupId>com.google.cloud.tools</groupId>
 					<artifactId>appengine-maven-plugin</artifactId>

--- a/spring-cloud-gcp-samples/pom.xml
+++ b/spring-cloud-gcp-samples/pom.xml
@@ -103,7 +103,7 @@
 							</includes>
 							<classesDirectory>${project.build.outputDirectory}</classesDirectory>
 							<systemPropertyVariables>
-								<it.storage>true</it.storage>
+								<it.pubsub>true</it.pubsub>
 							</systemPropertyVariables>
 						</configuration>
 					</plugin>

--- a/spring-cloud-gcp-samples/pom.xml
+++ b/spring-cloud-gcp-samples/pom.xml
@@ -99,7 +99,7 @@
 							<excludes combine.self="override" />
 							<includes>
 								<!--including all integration tests for testing purposes.-->
-								<include>**/*IntegrationTests.java</include>
+								<include>${integration-test.pattern}</include>
 							</includes>
 							<classesDirectory>${project.build.outputDirectory}</classesDirectory>
 							<systemPropertyVariables>

--- a/spring-cloud-gcp-samples/pom.xml
+++ b/spring-cloud-gcp-samples/pom.xml
@@ -79,6 +79,33 @@
 
 	<profiles>
 		<profile>
+			<id>native-sample</id>
+			<build>
+				<plugins>
+					<plugin>
+						<groupId>org.graalvm.buildtools</groupId>
+						<artifactId>native-maven-plugin</artifactId>
+						<version>0.9.20</version>
+						<configuration>
+							<buildArgs>
+								<buildArg>--trace-class-initialization=org.apache.commons.logging.LogFactoryService</buildArg>
+								<buildArg>--initialize-at-build-time=org.apache.commons.logging.LogFactory</buildArg>
+							</buildArgs>
+						</configuration>
+						<executions>
+							<execution>
+								<id>build-native</id>
+								<goals>
+									<goal>build</goal>
+								</goals>
+								<phase>package</phase>
+							</execution>
+						</executions>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
+		<profile>
 			<id>spring-cloud-gcp-ci-it</id>
 			<build>
 				<plugins>

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-data-multi-sample/README.adoc
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-data-multi-sample/README.adoc
@@ -1,6 +1,7 @@
 = Spring Framework on Google Cloud Cloud Spanner and Datastore Combined Usage Example
 
 This code sample demonstrates how to use both link:../../spring-cloud-gcp-starters/spring-cloud-gcp-starter-data-spanner[Spring Data Cloud Spanner] and link:../../spring-cloud-gcp-starters/spring-cloud-gcp-starter-data-datastore[Spring Data Cloud Datastore] using the Spring Data Cloud Datastore modules in a single Spring application.
+This sample also demonstrates usage of transactions with both modules.
 
 == Running the example
 

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-data-multi-sample/src/main/java/com/example/MultipleDataModuleExample.java
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-data-multi-sample/src/main/java/com/example/MultipleDataModuleExample.java
@@ -26,11 +26,11 @@ import org.springframework.context.annotation.Bean;
 @SpringBootApplication
 public class MultipleDataModuleExample {
 
-  // A Spring Data Datastore repository
-  @Autowired PersonRepository personRepository;
+  // Internally uses a Spring Data Datastore repository
+  @Autowired private PersonService personService;
 
-  // A Spring Data Cloud Spanner repository
-  @Autowired TraderRepository traderRepository;
+  // Internally uses a Spring Data Cloud Spanner repository
+  @Autowired private TraderService traderService;
 
   public static void main(String[] args) {
     SpringApplication.run(MultipleDataModuleExample.class, args);
@@ -41,19 +41,19 @@ public class MultipleDataModuleExample {
     return args -> {
       System.out.println("Deleting all entities.");
 
-      this.personRepository.deleteAll();
-      this.traderRepository.deleteAll();
+      this.personService.deleteAll();
+      this.traderService.deleteAll();
 
-      System.out.println("The number of Person entities is now: " + this.personRepository.count());
-      System.out.println("The number of Trader entities is now: " + this.traderRepository.count());
+      System.out.println("The number of Person entities is now: " + this.personService.count());
+      System.out.println("The number of Trader entities is now: " + this.traderService.count());
 
       System.out.println("Saving one entity with each repository.");
 
-      this.traderRepository.save(new Trader("id1", "trader", "one"));
-      this.personRepository.save(new Person(1L, "person1"));
+      this.traderService.save(new Trader("id1", "trader", "one"));
+      this.personService.save(new Person(1L, "person1"));
 
-      System.out.println("The number of Person entities is now: " + this.personRepository.count());
-      System.out.println("The number of Trader entities is now: " + this.traderRepository.count());
+      System.out.println("The number of Person entities is now: " + this.personService.count());
+      System.out.println("The number of Trader entities is now: " + this.traderService.count());
     };
   }
 }

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-data-multi-sample/src/main/java/com/example/PersonService.java
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-data-multi-sample/src/main/java/com/example/PersonService.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(transactionManager = "spannerTransactionManager")
+public class PersonService {
+
+  private final PersonRepository personRepository;
+
+  public PersonService(PersonRepository personRepository) {
+    this.personRepository = personRepository;
+  }
+
+  public Person save(Person person) {
+    return this.personRepository.save(person);
+  }
+
+  public void deleteAll() {
+    this.personRepository.deleteAll();
+  }
+
+  public Long count() {
+    return this.personRepository.count();
+  }
+}

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-data-multi-sample/src/main/java/com/example/TraderService.java
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-data-multi-sample/src/main/java/com/example/TraderService.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(transactionManager = "datastoreTransactionManager")
+public class TraderService {
+
+  private final TraderRepository traderRepository;
+
+  public TraderService(TraderRepository traderRepository) {
+    this.traderRepository = traderRepository;
+  }
+
+  public Trader save(Trader trader) {
+    return this.traderRepository.save(trader);
+  }
+
+  public void deleteAll() {
+    this.traderRepository.deleteAll();
+  }
+
+  public Long count() {
+    return this.traderRepository.count();
+  }
+}

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-pubsub-reactive-sample/pom.xml
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-pubsub-reactive-sample/pom.xml
@@ -80,6 +80,15 @@
 					<skip>true</skip>
 				</configuration>
 			</plugin>
+			<plugin>
+				<groupId>org.graalvm.buildtools</groupId>
+				<artifactId>native-maven-plugin</artifactId>
+				<configuration>
+					<buildArgs>
+						<arg>-H:+RunReachabilityHandlersConcurrently</arg>
+					</buildArgs>
+				</configuration>
+			</plugin>
 		</plugins>
 	</build>
 </project>


### PR DESCRIPTION
Temp draft to hold on changes. 
These pubsub samples works out-of-box:
`spring-cloud-gcp-pubsub-sample`
`spring-cloud-gcp-pubsub-reactive-sample`
`spring-cloud-gcp-integration-pubsub-sample`

PubSub modules (`spring-cloud-gcp-pubsub` and `spring-cloud-gcp-pubsub-stream-binder`) do not contain any integration tests. Rely on sample test to serve as integration tests.

Look to run tests for each of above samples.

What's in this PR so far:
- pom profiles for native build/test on samples and parent project. (https://github.com/mpeddada1/spring-cloud-gcp-current/commit/e2baa40d339066d71c8af46b4e34dd6e2065cd35, https://github.com/mpeddada1/spring-cloud-gcp-current/commit/e2baa40d339066d71c8af46b4e34dd6e2065cd35)
- add system property to allow tests that require `it.pubsub` be picked up by surefire. (https://github.com/mpeddada1/spring-cloud-gcp-current/commit/018f065f179bc98b11ca7409748ee00ad630f6a5)
- RunReachabilityHandlersConcurrently workaround for pubsub-reactive-sample (https://github.com/mpeddada1/spring-cloud-gcp-current/commit/c9fb0a15cff14cf61b585dc1769fc02242d90703)
  - error: `Fatal error: java.lang.TypeNotPresentException: Type kotlinx.serialization.StringFormat not present`
