### PR TITLE
chore: verify behavior with static json instead of Feature classes [Do Not Merge]

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -386,6 +386,7 @@
 						<buildArgs>
 							<buildArg>--trace-class-initialization=org.apache.commons.logging.LogFactoryService</buildArg>
 							<buildArg>--initialize-at-build-time=org.apache.commons.logging.LogFactory</buildArg>
+							<buildArg>-H:+RunReachabilityHandlersConcurrently</buildArg>
 						</buildArgs>
 						<classesDirectory>${project.build.outputDirectory}</classesDirectory>
 						<metadataRepository>

--- a/spring-cloud-gcp-storage/pom.xml
+++ b/spring-cloud-gcp-storage/pom.xml
@@ -23,6 +23,17 @@
 		<dependency>
 			<groupId>com.google.cloud</groupId>
 			<artifactId>google-cloud-storage</artifactId>
+			<version>2.22.5-SNAPSHOT</version>
+		</dependency>
+		<dependency>
+			<groupId>com.google.api</groupId>
+			<artifactId>gax</artifactId>
+			<version>2.28.2-SNAPSHOT</version>
+		</dependency>
+		<dependency>
+			<groupId>com.google.api</groupId>
+			<artifactId>gax-grpc</artifactId>
+			<version>2.28.2-SNAPSHOT</version>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.integration</groupId>

--- a/spring-cloud-gcp-vision/pom.xml
+++ b/spring-cloud-gcp-vision/pom.xml
@@ -16,8 +16,24 @@
 
 	<dependencies>
 		<dependency>
+			<groupId>org.graalvm.sdk</groupId>
+			<artifactId>graal-sdk</artifactId>
+			<version>22.3.2</version>
+		</dependency>
+		<dependency>
 			<groupId>com.google.cloud</groupId>
 			<artifactId>google-cloud-vision</artifactId>
+			<version>3.17.0-SNAPSHOT</version>
+		</dependency>
+		<dependency>
+			<groupId>com.google.api</groupId>
+			<artifactId>gax</artifactId>
+			<version>2.28.2-SNAPSHOT</version>
+		</dependency>
+		<dependency>
+			<groupId>com.google.api</groupId>
+			<artifactId>gax-grpc</artifactId>
+			<version>2.28.2-SNAPSHOT</version>
 		</dependency>
 
 		<dependency>
@@ -25,11 +41,15 @@
 			<artifactId>spring-core</artifactId>
 		</dependency>
 
+		<!-- Use SNAPSHOT storage version-->
 		<dependency>
 			<groupId>com.google.cloud</groupId>
 			<artifactId>spring-cloud-gcp-storage</artifactId>
 			<optional>true</optional>
+
 		</dependency>
+
+
 
 		<!-- Integration Test Dependencies -->
 		<dependency>

--- a/spring-cloud-gcp-vision/src/test/java/com/google/cloud/spring/vision/DocumentOcrTemplateTests.java
+++ b/spring-cloud-gcp-vision/src/test/java/com/google/cloud/spring/vision/DocumentOcrTemplateTests.java
@@ -25,6 +25,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mockito;
+import org.springframework.context.annotation.ImportRuntimeHints;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 @ExtendWith(SpringExtension.class)

--- a/spring-cloud-gcp-vision/src/test/java/com/google/cloud/spring/vision/it/CloudVisionTemplateIntegrationTests.java
+++ b/spring-cloud-gcp-vision/src/test/java/com/google/cloud/spring/vision/it/CloudVisionTemplateIntegrationTests.java
@@ -29,7 +29,7 @@ import org.springframework.core.io.Resource;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
-@EnabledIfSystemProperty(named = "it.vision", matches = "true")
+//@EnabledIfSystemProperty(named = "it.vision", matches = "true")
 @ExtendWith(SpringExtension.class)
 @ContextConfiguration(classes = {VisionTestConfiguration.class})
 class CloudVisionTemplateIntegrationTests {

--- a/spring-cloud-gcp-vision/src/test/java/com/google/cloud/spring/vision/it/DocumentOcrTemplateIntegrationTests.java
+++ b/spring-cloud-gcp-vision/src/test/java/com/google/cloud/spring/vision/it/DocumentOcrTemplateIntegrationTests.java
@@ -36,7 +36,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
-@EnabledIfSystemProperty(named = "it.vision", matches = "true")
+//@EnabledIfSystemProperty(named = "it.vision", matches = "true")
 @ExtendWith(SpringExtension.class)
 @ContextConfiguration(classes = {VisionTestConfiguration.class})
 class DocumentOcrTemplateIntegrationTests {

--- a/spring-cloud-gcp-vision/src/test/resources/META-INF/native-image/resource-config.json
+++ b/spring-cloud-gcp-vision/src/test/resources/META-INF/native-image/resource-config.json
@@ -1,0 +1,12 @@
+{
+  "resources":{
+    "includes":[
+      {
+        "pattern":"\\Qdocuments/multi-page-dummy.pdf\\E"
+      },
+      {
+        "pattern":"\\Qdocuments/single-page-dummy.pdf\\E"
+      }
+    ]},
+  "bundles":[]
+}

--- a/spring-cloud-gcp-vision/src/test/resources/application-test.properties
+++ b/spring-cloud-gcp-vision/src/test/resources/application-test.properties
@@ -1,0 +1,1 @@
+gcs-write-bucket=vision-integration-test-bucket


### PR DESCRIPTION
[Not meant to be merged] PR to emulate local development environment for testing beahvior of ITs with static jsons.
GoogleJsonClientFeature is still needed for the tests to pass but the other Feature classes including ProtobufMessageFeature, NettyFeature can be replaced with configurations in https://github.com/mpeddada1/google-cloud-java/pull/6

```
[1/7] Initializing...                                                                                   (38.1s @ 0.54GB)
 Version info: 'GraalVM 22.2.0 Java 17 CE'
 Java version info: '17.0.4+8-jvmci-22.2-b06'
 C compiler: gcc (linux, x86_64, 12.2.0)
 Garbage collector: Serial GC
 5 user-specific feature(s)
 - com.google.api.gax.nativeimage.GoogleJsonClientFeature
 - com.oracle.svm.thirdparty.gson.GsonFeature
 - org.graalvm.home.HomeFinderFeature: Finds GraalVM paths and its version number
 - org.graalvm.junit.platform.JUnitPlatformFeature
 - org.springframework.aot.nativex.feature.PreComputeFieldFeature
```

For local testing:
`mvn verify -Pspring-native`